### PR TITLE
Correct exception handling to account for namespace and proper Exception...

### DIFF
--- a/src/Embedly/Embedly.php
+++ b/src/Embedly/Embedly.php
@@ -100,7 +100,7 @@ class Embedly {
         preg_match('/^(https?:\/\/)?([^\/]+)(:\d+)?\/?$/', $host, $matches);
 
         if (!$matches) {
-            throw new Error(sprintf('invalid host %s', host));
+            throw new \Exception(sprintf('invalid host %s', host));
         }
 
         $hostname = $matches[2];
@@ -311,7 +311,7 @@ class Embedly {
     {	
         $res = curl_exec($ch);
         if (false === $res) {
-            throw new Exception(curl_error($ch), curl_errno($ch));
+            throw new \Exception(curl_error($ch), curl_errno($ch));
         }
         return $res;
     }


### PR DESCRIPTION
Embedly.php is namespaced, so at one point I received this error:

Fatal error: Class 'Embedly\Exception' not found in /home/ows/site/libs/Embedly/Embedly.php on line 314

When looking, I think there was also an incorrect call to "new Error" that should have escaped the namespace and be called "Exception".
