### PR TITLE
phpunit and behat should be placed in composer require-dev not require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     ] ,
     "require":
     {
-        "php": ">=5.3.0",
+        "php": ">=5.3.0"
+    },
+    "require-dev":
+    {
         "behat/behat": "2.4.*@stable",
         "phpunit/phpunit": "3.7.*"
     },


### PR DESCRIPTION
That is because if you use this library in production you end up with autoloading whole phpunit and behat, of course we don't want to do that

See http://getcomposer.org/doc/04-schema.md#require-dev for more info
