### PR TITLE
README.rst: specify language in codeblocks to benefit from syntax highlighting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,23 +19,20 @@ To install::
 1. Download the `composer.phar` executable or use the installer.
 ::
     curl -sS https://getcomposer.org/installer | php
-2. Create a composer.json defining your dependencies. Note that this example is a short version for applications that are not meant to be published as a packages themselves.
+
+2. Install this package with comopser:
 ::
-    {
-      "require": [
-        "embedly/embedly-php"
-      ]
-    }
-3. Run Composer: ``php composer.phar install``
+    ``php composer.phar require embedly/embedly-php``
 
 Examples
 ^^^^^^^^
 
-::
+.. code-block:: php
 
   <?php
   require_once('Embedly/src/Embedly/Embedly.php');  // if using pear
   // require_once('src/Embedly/Embedly.php');  // if using source
+  // require_once(__DIR__ . '/vendor/autoload.php'); // if using Composer 
 
   $api = new Embedly\Embedly(array('user_agent' => 'Mozilla/5.0 (compatible; mytestapp/1.0)'));
 


### PR DESCRIPTION
It enhances README readability a lot:

![image](https://user-images.githubusercontent.com/1551971/66985121-69bca780-f0bc-11e9-949f-9c6c9f3a5fdc.png)
