### PR TITLE
Add curl PHP extension as a composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ] ,
     "require":
     {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-curl": "*"
     },
     "require-dev":
     {


### PR DESCRIPTION
Since curl is required for this extension to work, we should add it as a platform requirement.
What do you think?